### PR TITLE
[FIX] Support for engine add-on

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,9 @@
 module.exports = {
   name: 'ember-initials',
 
-  included: function(app) {
-    this._super.included(app);
-    app.import('node_modules/blueimp-md5/js/md5.min.js', { using: [{ transformation: 'amd', as: 'md5' }]});
+  included: function() {
+    this._super.included.apply(this, arguments);
+    let target = this._findHost();
+    target.import('node_modules/blueimp-md5/js/md5.min.js', { using: [{ transformation: 'amd', as: 'md5' }]});
   }
 }


### PR DESCRIPTION
`app.import` wasn't targeting my engine's dummy app, so this should provide wider support.